### PR TITLE
Revert ":arrow_up: Bump cypress from 4.9.0 to 4.10.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5172,9 +5172,9 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "cypress": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.10.0.tgz",
-      "integrity": "sha512-eFv1WPp4zFrAgZ6mwherBGVsTpHvay/hEF5F7U7yfAkTxsUQn/ZG/LdX67fIi3bKDTQXYzFv/CvywlQSeug8Bg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.9.0.tgz",
+      "integrity": "sha512-qGxT5E0j21FPryzhb0OBjCdhoR/n1jXtumpFFSBPYWsaZZhNaBvc3XlBUDEZKkkXPsqUFYiyhWdHN/zo0t5FcA==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "babel-eslint": "10.1.0",
     "chai": "4.2.0",
     "chai-jest-diff": "1.0.2",
-    "cypress": "4.10.0",
+    "cypress": "4.9.0",
     "dirty-chai": "2.0.1",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.11.0",


### PR DESCRIPTION
This reverts commit 06abd6bd93064679389be7aa0a9d55fa4984dd03.